### PR TITLE
Allow specifying password file in envvar for password caching

### DIFF
--- a/src/init.go
+++ b/src/init.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/opencoff/ovpn-tool/internal/utils"
-	"github.com/opencoff/ovpn-tool/pki"
+	"github.com/opencoff/go-pki"
 	flag "github.com/opencoff/pflag"
 )
 


### PR DESCRIPTION
This is so that, for any command other than the `init` one where you have to specify your password, you can make it so it won't ask for the password by specifying the envvar.  If you don't specify that envvar then it will still ask for the password.

```
echo "mypass" > pw.txt
export PASSWD_FILE=pw.txt
ovpn-tool foo.db list
```

This helps when using the tool in situations where there may not be a terminal in which to enter the password, to allow use in automation or integration.