### PR TITLE
Specify explicit key usage and add name verify field for verify-x509-name option

### DIFF
--- a/src/export.go
+++ b/src/export.go
@@ -414,11 +414,12 @@ script-security 2
 tls-cipher TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384:TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256
 cipher AES-256-GCM
 auth-nocache
-remote-cert-tls server
+# when a ECDSA key is used then "keyAgreement" flag is needed for being ECDH "capable" (as opposed to ephemeral ECDHE)
+remote-cert-ku a8 a0 80 88
 tls-version-min 1.2
 
 # Verify the remote server's common name
-verify-x509-name "{{ .ServerCommonName }}"
+verify-x509-name "{{ .ServerCommonName }}" name
 
 # Inline certs, keys and tls-crypt follows
 <ca>


### PR DESCRIPTION
See here for why the change to verifiy-x509-name option is needed: https://community.openvpn.net/openvpn/wiki/GettingStartedwithOVPN#Evenstrictercertificatechecks

Apparently using `tls-remote "{{ .ServerCommonName }}"` would also work for that: https://unix.stackexchange.com/questions/345296/openvpn-verify-x509-name#379584

As for the `remote-cert-ku` option addition, my client refused to connect with `remote-cert-tls server` because that macro was not setting the key usage flags correctly.  So setting them manually did the trick for me.  Some more info [here](https://v13.gr/2014/09/11/openvpn-and-remote-cert-tls-server/) (although `f8` did not work for me) and [https://github.com/OpenVPN/easy-rsa/issues/35#issuecomment-49101789](here)