### PR TITLE
Add ability to specify a passwd file in an envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ Organization Unit Name etc. See `init --help` for additional details.
 The default lifetime of the CA is 5 years; you can change this via
 the `-V` (`--validity`) option to "init".
 
+From here you can specify the password every time your run the command or
+if you're using some automation scripts specify it via a file:
+
+```
+echo -n "mypass" > pw.txt
+export PASSWD_FILE=pw.txt
+ovpn-tool foo.db list
+```
+
 ### Initialize a new CA by Importing from a JSON file
 If you are using any version of ovpn-tool **prior** to v0.9.x, you
 must first export the DB into a JSON file *using the v0.8.x version

--- a/src/init.go
+++ b/src/init.go
@@ -20,12 +20,17 @@ import (
 	flag "github.com/opencoff/pflag"
 )
 
-// Open an existing CA or fail
+// OpenCA will open an existing CA or fail
 func OpenCA(db string) *pki.CA {
+	pw, usingPwFile := pwFromPasswdFile()
+
 	// we only ask _once_
-	pw, err := utils.Askpass("Enter password for DB", false)
-	if err != nil {
-		die("%s", err)
+	if !usingPwFile {
+		var err error
+		pw, err = utils.Askpass("Enter password for DB", false)
+		if err != nil {
+			die("%s", err)
+		}
 	}
 
 	p := pki.Config{
@@ -138,4 +143,18 @@ Options:
 func years(n uint) time.Duration {
 	day := 24 * time.Hour
 	return (6 * time.Hour) + (time.Duration(n*365) * day)
+}
+
+func pwFromPasswdFile() (string, bool) {
+	f := os.Getenv("PASSWD_FILE")
+	if f == "" {
+		return "", false
+	}
+
+	data, err := ioutil.ReadFile(f)
+	if err != nil {
+		die("%s", err)
+	}
+
+	return string(data), true
 }


### PR DESCRIPTION
This is so that, for any command other than the `init` one where you have to specify your password, you can make it so it won't ask for the password by specifying the envvar.  If you don't specify that envvar then it will still ask for the password.

```
echo -n "mypass" > pw.txt
export PASSWD_FILE=pw.txt
ovpn-tool foo.db list
```

This helps when using the tool in situations where there may not be a terminal in which to enter the password, to allow use in automation or integration.